### PR TITLE
Fixed: Edge offset is not being set in Firefox

### DIFF
--- a/src/components/Edge.vue
+++ b/src/components/Edge.vue
@@ -21,10 +21,6 @@ export default {
     start: [Object, HTMLElement],
     end: [Object, HTMLElement],
     color: String,
-    bezierOffset: {
-      type: Number,
-      default: 250
-    },
     padding: {
       type: Number,
       default: 256
@@ -88,6 +84,9 @@ export default {
         x: this.centerEnd.x - this.svgRect.x,
         y: this.centerEnd.y - this.svgRect.y
       }
+    },
+    bezierOffset () {
+      return 0.5 * (this.centerEnd.x - this.centerStart.x)
     }
   }
 }

--- a/src/components/Edge.vue
+++ b/src/components/Edge.vue
@@ -86,7 +86,7 @@ export default {
       }
     },
     bezierOffset () {
-      return 0.5 * (this.centerEnd.x - this.centerStart.x)
+      return Math.abs(0.5 * (this.centerEnd.x - this.centerStart.x))
     }
   }
 }

--- a/src/components/Edge.vue
+++ b/src/components/Edge.vue
@@ -2,7 +2,7 @@
   <svg
     :width="svgRect.width"
     :height="svgRect.height"
-    :style="`position: absolute; left: ${svgRect.x}; top: ${svgRect.y};`"
+    :style="`position: absolute; left: ${svgRect.x}px; top: ${svgRect.y}px;`"
   >
     <path
       fill="none"


### PR DESCRIPTION
The edge offset issue in Firefox has been resolved by adding the 'px' unit to the style values 'left' and 'top'. The position is now being applied correctly.