### PR TITLE
Make node text non-selectable

### DIFF
--- a/src/components/Connector.vue
+++ b/src/components/Connector.vue
@@ -1,10 +1,10 @@
 <template>
   <div :class="this.output ? 'float-right' : 'float-left'" id="container">
-    <div id="name" v-if="output">{{ spec.name }}</div>
+    <div id="name" class="non-selectable" v-if="output">{{ spec.name }}</div>
     <div id="stump" v-touch-pan.mouse="onPan">
       <div id="connector" :style="style" ref="connector" />
     </div>
-    <div id="name" v-if="input">{{ spec.name }}</div>
+    <div id="name" class="non-selectable" v-if="input">{{ spec.name }}</div>
   </div>
 </template>
 

--- a/src/components/Node.vue
+++ b/src/components/Node.vue
@@ -1,7 +1,7 @@
 <template>
   <q-card id="node" class="shadow-1" :style="style">
     <q-card-section class="header non-selectable text-center" v-touch-pan.mouse="onPan">
-      <img id="icon" v-if="instance.spec.icon" :src="instance.spec.icon" alt="">
+      <img id="icon" class="non-selectable" v-if="instance.spec.icon" :src="instance.spec.icon" alt="">
       {{ instance.title }}
     </q-card-section>
     <slot />

--- a/src/components/Node.vue
+++ b/src/components/Node.vue
@@ -1,6 +1,6 @@
 <template>
   <q-card id="node" class="shadow-1" :style="style">
-    <q-card-section class="header text-center" v-touch-pan.mouse="onPan">
+    <q-card-section class="header non-selectable text-center" v-touch-pan.mouse="onPan">
       <img id="icon" v-if="instance.spec.icon" :src="instance.spec.icon" alt="">
       {{ instance.title }}
     </q-card-section>


### PR DESCRIPTION
This prevents a text selection cursor appearing when hovering over node text
Before:
![](https://user-images.githubusercontent.com/31693992/69834817-2c137880-123d-11ea-9b17-8524c67b953d.png) ![](https://user-images.githubusercontent.com/31693992/69834832-451c2980-123d-11ea-8eb2-6b731ced6060.png)
After:
![](https://user-images.githubusercontent.com/31693992/69834842-5d8c4400-123d-11ea-840e-76f538218c5c.png) ![](https://user-images.githubusercontent.com/31693992/69834849-6f6de700-123d-11ea-8c5e-0a013ed08a40.png)

