### PR TITLE
Add Note node, make number node not accept non-number values

### DIFF
--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -37,6 +37,7 @@ import PEdge from '../components/Edge'
 import Number from '../components/nodes/Number'
 import Average from '../components/nodes/Average'
 import Binarize from '../components/nodes/Binarize'
+import Note from '../components/nodes/Note'
 
 import { NodeInstance } from '../utils/instances'
 import types from '../utils/types'
@@ -44,7 +45,8 @@ import types from '../utils/types'
 const nodeTypes = {
   Number,
   Average,
-  Binarize
+  Binarize,
+  Note
 }
 
 export default {

--- a/src/components/nodes/Note.vue
+++ b/src/components/nodes/Note.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="q-px-md q-pt-md">
+    <q-input filled v-model="text" type="textarea" float-label="Textarea" :max-height="5" rows="3" placeholder="enter Text here"/>
+  </div>
+</template>
+
+<script>
+export default {
+  spec: {
+    id: 'std::note',
+    title: 'Note',
+    inputs: [],
+    outputs: []
+  }
+}
+</script>

--- a/src/components/nodes/Note.vue
+++ b/src/components/nodes/Note.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="q-px-md q-pt-md">
-    <q-input filled v-model="text" type="textarea" float-label="Textarea" :max-height="5" rows="3" placeholder="enter Text here"/>
+  <div class="q-px-md q-py-md">
+    <q-input filled v-model="text" type="textarea" float-label="Textarea" rows="3" placeholder="Enter text here"/>
   </div>
 </template>
 

--- a/src/components/nodes/Number.vue
+++ b/src/components/nodes/Number.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="q-px-md q-pt-md">
-    <q-input filled v-model="value" />
+    <q-input filled v-model="value" type="number" float-label="Number" max-height="5"/>
   </div>
 </template>
 

--- a/src/components/nodes/Number.vue
+++ b/src/components/nodes/Number.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="q-px-md q-pt-md">
-    <q-input filled v-model="value" type="number" float-label="Number" max-height="5"/>
+    <q-input filled v-model="value" type="number" float-label="Number" />
   </div>
 </template>
 


### PR DESCRIPTION
Added a Note node with a 3-lines expandable text field.
Typing a non-number in the Number node input will be ignored.
