### PR TITLE
Fix edge bug with nodes that have no connector

### DIFF
--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -123,6 +123,8 @@ export default {
         let closest = null
         let closestDist = null
         for (let node of this.$refs.nodes) {
+          // Ignore nodes that have no connectors.
+          if (!node.$refs.connectors) continue
           for (let connector of node.$refs.connectors) {
             let edge = connector.output ? new EdgeInstance(connector, this.newEdge.end) : new EdgeInstance(this.newEdge.start, connector)
             // Only snap if the potential edge is valid.


### PR DESCRIPTION
Previously, after adding a Note node to the canvas, connecting nodes with edges would no longer work. This branch fixes the issue.