### PR TITLE
Add `any` type and explicit type casting

### DIFF
--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -122,7 +122,7 @@ export default {
 
       // Type checking
       // TODO: more elaborate typechecking (bundles, casting)
-      if (edge.start.spec.type !== edge.end.spec.type) return false
+      if (!types.isCastable(edge.start.spec.type, edge.end.spec.type)) return false
 
       // Each input may be connected once only
       if (edge.end.connected) return false

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -8,7 +8,6 @@
           ref="newEdge"
           :start="newEdge.start.$refs ? newEdge.start.$refs.connector : newEdge.start"
           :end="newEdge.end.$refs ? newEdge.end.$refs.connector : newEdge.end"
-          :color="newEdge.color"
         />
         <p-edge
           v-for="edge in edges"
@@ -16,7 +15,6 @@
           :key="edge.id"
           :start="edge.start.$refs.connector"
           :end="edge.end.$refs.connector"
-          :color="edge.color"
         />
         <p-node
           v-for="node in nodes"
@@ -187,8 +185,7 @@ export default {
             this.newEdgeForwards = true
           } else {
             const from = event.component
-            const color = types.colors[event.component.spec.type]
-            this.newEdge = event.isOutput ? new EdgeInstance(from, to, color) : new EdgeInstance(to, from, color)
+            this.newEdge = event.isOutput ? new EdgeInstance(from, to) : new EdgeInstance(to, from)
             event.component.connecting = true
             this.newEdgeForwards = event.isOutput
           }

--- a/src/components/Edge.vue
+++ b/src/components/Edge.vue
@@ -4,9 +4,22 @@
     :height="svgRect.height"
     :style="`position: absolute; left: ${svgRect.x}px; top: ${svgRect.y}px;`"
   >
+    <defs>
+      <linearGradient
+        :id="`gradient-${id}`"
+        gradientUnits="userSpaceOnUse"
+        :x1="relativeStart.x"
+        :y1="relativeStart.y"
+        :x2="relativeEnd.x"
+        :y2="relativeEnd.y"
+      >
+        <stop offset="50%"  :stop-color="startColor" />
+        <stop offset="90%" :stop-color="endColor" />
+      </linearGradient>
+    </defs>
     <path
       fill="none"
-      :stroke="color"
+      :stroke="`url(#gradient-${id})`"
       stroke-width="4"
       :d="`
         M ${relativeStart.x} ${relativeStart.y}
@@ -19,14 +32,16 @@
 </template>
 
 <script lang="ts">
+import uuid from '../utils/uuid'
+
 export default {
   props: {
     start: [Object, HTMLElement],
-    end: [Object, HTMLElement],
-    color: String
+    end: [Object, HTMLElement]
   },
   data () {
     return {
+      id: uuid(),
       isMounted: false,
       centerStart: { x: 0, y: 0 },
       centerEnd: { x: 0, y: 0 }
@@ -64,6 +79,12 @@ export default {
     },
     padding () {
       return this.bezierOffset
+    },
+    startColor () {
+      return this.start.style.borderColor
+    },
+    endColor () {
+      return this.end.style ? this.end.style.borderColor : this.startColor
     }
   },
   methods: {

--- a/src/components/nodes/miscellanious/Preview.vue
+++ b/src/components/nodes/miscellanious/Preview.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    {{ value }}
+  </div>
+</template>
+
+<script>
+
+export default {
+  spec: {
+    id: 'std::preview',
+    title: 'Preview',
+    inputs: [
+      {
+        id: 'value',
+        name: 'Value',
+        type: 'any'
+      }
+    ],
+    outputs: []
+  },
+  data: () => ({
+    value: null
+  })
+}
+</script>

--- a/src/components/nodes/miscellanious/miscellanious.js
+++ b/src/components/nodes/miscellanious/miscellanious.js
@@ -1,5 +1,7 @@
+import PNPreview from './Preview'
 import PNNote from './Note'
 
 export default {
+  PNPreview,
   PNNote
 }

--- a/src/utils/instances.js
+++ b/src/utils/instances.js
@@ -24,10 +24,9 @@ export class NodeInstance {
 }
 
 export class EdgeInstance {
-  constructor (start, end, color) {
+  constructor (start, end) {
     this.id = uuid()
     this.start = start
     this.end = end
-    this.color = color
   }
 }

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -8,7 +8,7 @@ export default {
   },
   casts: {
     image: ['any'],
-    number: ['any', 'boolean'],
+    number: ['any', 'text', 'boolean'],
     boolean: ['any'],
     text: ['any', 'boolean']
   },

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -7,14 +7,13 @@ export default {
     text: '#d47b00'
   },
   casts: {
-    image: ['any'],
-    number: ['any', 'text', 'boolean'],
-    boolean: ['any'],
-    text: ['any', 'boolean']
+    'any': ['image', 'number', 'boolean', 'text'],
+    'boolean': ['number', 'text'],
+    'text': ['number']
   },
   isCastable (from, to) {
     if (from === to) return true
-    if (this.casts[from] && this.casts[from].includes(to)) return true
+    if (this.casts[to] && this.casts[to].includes(from)) return true
     return false
   }
 }

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -1,8 +1,20 @@
 export default {
   colors: {
+    any: '#a0a0a0',
     image: '#92d050',
     number: '#00b0f0',
     boolean: '#ff3fcc',
     text: '#d47b00'
+  },
+  casts: {
+    image: ['any'],
+    number: ['any', 'boolean'],
+    boolean: ['any'],
+    text: ['any', 'boolean']
+  },
+  isCastable (from, to) {
+    if (from === to) return true
+    if (this.casts[from] && this.casts[from].includes(to)) return true
+    return false
   }
 }


### PR DESCRIPTION
Added `any` type and rudimentary type casting. Edge colors are now also fetched directly from the attached connectors, and interpolated to indicate casting.

![](https://user-images.githubusercontent.com/31693992/72088564-b950ef00-330a-11ea-9915-2cb701f06896.png)
