### PR TITLE
Remove variadic shuffling

### DIFF
--- a/src/components/Node.vue
+++ b/src/components/Node.vue
@@ -122,24 +122,6 @@ export default {
           }
           channel.splice(lastIndex + 1, 0, newSpec)
           channel.counts[newSpec.specId]++
-        } else {
-          if (afterSpec.variadic.collapse) {
-            // Move unconnected connector behind last connected one
-            channel.reverse()
-            const emptyIndex = channel.findIndex(connector =>
-              connector.specId === afterSpec.specId &&
-              !this.$refs.connectors.filter(component => component.spec === connector)[0].connected
-            )
-            const lastIndex = channel.findIndex(connector =>
-              connector.specId === afterSpec.specId &&
-              this.$refs.connectors.filter(component => component.spec === connector)[0].connected
-            )
-            if (emptyIndex > lastIndex) {
-              // Move empty connector before last connected (because the channel is reversed)
-              channel.splice(lastIndex, 0, channel.splice(emptyIndex, 1)[0])
-            }
-            channel.reverse()
-          }
         }
       }
       this.$nextTick(function () {


### PR DESCRIPTION
This may or may not make sense.
It seems to me, connecting variadics with minima out of sequence is more user-friendly.
For example, when creating and connection an arithmetic node (such as Addition) connecting the bottom one, while the top one stays seems more intuitive.

Before, connecting to any input would always move any free connectors behind all connected ones, always leaving this situation: ![](https://user-images.githubusercontent.com/31693992/72115651-1d45d880-3348-11ea-9c94-818f52b99aaf.png)

But without this shuffling behaviour, connections may be made in any order: ![](https://user-images.githubusercontent.com/31693992/72115646-17e88e00-3348-11ea-8b07-79749908e29f.png)

Newly created connectors (when all slots are connected) will still start out after the bottom most connected connector: 
![](https://user-images.githubusercontent.com/31693992/72115782-7a418e80-3348-11ea-98c4-374657038979.png)

This change does not touch "collapsing", the deletion of variadic connectors when being disconnected (while the minimum is still satisfied), and previously this shuffling behaviour was not affecting variadics with `collapse` turned off anyways, so those (e.g. group inputs and outputs) also behave unchanged.

Any opinions?