### PR TITLE
Properly choose edge color on nodes from end to start

### DIFF
--- a/src/components/Edge.vue
+++ b/src/components/Edge.vue
@@ -85,7 +85,7 @@ export default {
       return this.bezierOffset
     },
     startColor () {
-      return this.start.style.borderColor
+      return this.start.style ? this.start.style.borderColor : this.endColor
     },
     endColor () {
       return this.end.style ? this.end.style.borderColor : this.startColor


### PR DESCRIPTION
This fixes errors on edges dragged from an input to an output.
This looks like it will not terminate when both the start style and the end style are undefined. However, edges that are not connected to at least one connector are not possible at the moment, and probably not intended in the future.