### PR TITLE
Ignore duplicate calculations

### DIFF
--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -161,7 +161,6 @@ export default {
     async compute () {
       // A node is considered ready when no dependency is either scheduled or being computed
       const ready = entry => {
-        // if (this.computing.has(entry.node)) return false
         for (let dependency of entry.dependencies) {
           if (this.computing.has(dependency)) return false
           if (this.computeQueue.find(entry => entry.node === dependency)) return false

--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -181,9 +181,7 @@ export default {
 
         const result = await entry.node.instance.calculate(component)
 
-        const cancelled = calculationId !== this.computations[entry.node.instance.id]
-
-        if (!cancelled) {
+        if (calculationId === this.computations[entry.node.instance.id]) {
           entry.node.instance.applyCalculation(result)
           const outEdges = entry.node.edges.filter(edge => edge.start.node === entry.node)
           outEdges.forEach(edge => edge.transport())

--- a/src/utils/instances.js
+++ b/src/utils/instances.js
@@ -76,19 +76,22 @@ export class NodeInstance {
         else input[id] = input[id].value
       }
       // Execute node computation
-      const result = await calculate.bind(this)(input, component)
-      // Retreive output map
-      const outputIds = new Set(this.outputs.map(connector => connector.specId))
-      outputIds.forEach(id => {
-        const output = this.output(id)
-        if (output instanceof Array) {
-          if (result[id]) {
-            if (!(result[id] instanceof Array)) throw new Error(`Output ${id} of ${this.title} node is expected to be variadic, but is not`)
-            output.forEach((connector, index) => { connector.value = result[id][index] })
-          } else output.forEach((connector, index) => { connector.value = undefined })
-        } else output.value = result && result[id]
-      })
+      return calculate.bind(this)(input, component)
     }
+  }
+
+  applyCalculation (result) {
+    // Retreive output map
+    const outputIds = new Set(this.outputs.map(connector => connector.specId))
+    outputIds.forEach(id => {
+      const output = this.output(id)
+      if (output instanceof Array) {
+        if (result[id]) {
+          if (!(result[id] instanceof Array)) throw new Error(`Output ${id} of ${this.title} node is expected to be variadic, but is not`)
+          output.forEach((connector, index) => { connector.value = result[id][index] })
+        } else output.forEach((connector, index) => { connector.value = undefined })
+      } else output.value = result && result[id]
+    })
   }
 }
 

--- a/src/utils/instances.js
+++ b/src/utils/instances.js
@@ -78,16 +78,16 @@ export class NodeInstance {
       // Execute node computation
       const result = await calculate.bind(this)(input, component)
       // Retreive output map
-      if (result) {
-        const outputIds = new Set(this.outputs.map(connector => connector.specId))
-        outputIds.forEach(id => {
-          const output = this.output(id)
-          if (output instanceof Array) {
+      const outputIds = new Set(this.outputs.map(connector => connector.specId))
+      outputIds.forEach(id => {
+        const output = this.output(id)
+        if (output instanceof Array) {
+          if (result[id]) {
             if (!(result[id] instanceof Array)) throw new Error(`Output ${id} of ${this.title} node is expected to be variadic, but is not`)
             output.forEach((connector, index) => { connector.value = result[id][index] })
-          } else output.value = result[id]
-        })
-      }
+          } else output.forEach((connector, index) => { connector.value = undefined })
+        } else output.value = result && result[id]
+      })
     }
   }
 }


### PR DESCRIPTION
When a node is updated (/changed) while it is still executing (e.g. backend image processing) a new calculation will be started immediately, and the old one will still finish but not be applied afterwards.