### PR TITLE
Refresh node edges after image loading

### DIFF
--- a/src/components/nodes/miscellanious/Preview.vue
+++ b/src/components/nodes/miscellanious/Preview.vue
@@ -2,7 +2,7 @@
   <div class="text-center">
     <!-- TODO: display bools as True/False -->
     <div v-if="type === 'image'">
-      <img :src="value.url" width="100%" class="cursor-pointer" @click="lightbox = true"/>
+      <img :src="value.url" width="100%" class="cursor-pointer" @click="lightbox = true" @load="$parent.$parent.$emit('move', $parent.$parent)"/>
       <q-dialog v-model="lightbox" full-width full-height>
         <img :src="value.url" :style="{ 'max-width': '100%', 'max-height': '100%' }" />
       </q-dialog>

--- a/src/components/nodes/values/Image.vue
+++ b/src/components/nodes/values/Image.vue
@@ -1,6 +1,6 @@
 <template>
   <div >
-    <img v-if="image" :src="image.url" width="100%" class="cursor-pointer" @click="lightbox = true" />
+    <img v-if="image" :src="image.url" width="100%" class="cursor-pointer" @click="lightbox = true" @load="$parent.$parent.$emit('move', $parent.$parent)" />
     <q-dialog v-if="image" v-model="lightbox" full-width full-height>
       <img v-if="image" :src="image.url" :style="{ 'max-width': '100%', 'max-height': '100%' }" />
     </q-dialog>


### PR DESCRIPTION
Rather hacky way of preventing #65. It might be more elegant to emit a special `refresh` event from the node body and resolve the `$parent.$parent` reference in `Canvas.vue` (like with `onNodeChange`), however that would require extra Component methods and this way it can be emitted inline.
(This way is also more fragile if component parent relationships change, however that might break lots of things anyway).