### PR TITLE
Make connector names editable

### DIFF
--- a/src/components/Connector.vue
+++ b/src/components/Connector.vue
@@ -1,11 +1,11 @@
 <template>
   <div :class="this.output ? 'float-right' : 'float-left'" id="container">
-    <div id="name" class="non-selectable" v-if="output">{{ spec.name }}</div>
+    <div id="name" class="non-selectable" v-if="output"><q-input dense borderless input-class="text-right" v-model="spec.name"/></div>
     <div id="stump" v-touch-pan.mouse.prevent="handlePan">
       <div v-if="spec.bundle" class="cursor-pointer" style="position: relative;"><div id="bundle" /></div>
       <div id="connector" ref="connector" class="cursor-pointer" :style="style" />
     </div>
-    <div id="name" class="non-selectable" v-if="input">{{ spec.name }}</div>
+    <div id="name" class="non-selectable" v-if="input"><q-input dense borderless input-class="text-left" v-model="spec.name"/></div>
   </div>
 </template>
 

--- a/src/utils/instances.js
+++ b/src/utils/instances.js
@@ -3,9 +3,9 @@ import uuid from './uuid'
 export class ConnectorInstance {
   constructor (spec) {
     this.id = uuid()
-    this.value = undefined
     this.specId = spec instanceof ConnectorInstance ? spec.specId : spec.id
-    this.name = spec.name
+    this.name = spec instanceof ConnectorInstance ? spec.specName : spec.name
+    this.specName = this.name
     this.type = spec.type
     this.variadic = spec.variadic
     this.bundle = spec.bundle


### PR DESCRIPTION
Renaming of connectors. Does not cover node titles yet.
Newly created variadic connectors will get the original name.